### PR TITLE
MipMapping related fixes

### DIFF
--- a/VK9-Library/BufferManager.cpp
+++ b/VK9-Library/BufferManager.cpp
@@ -1692,6 +1692,11 @@ void BufferManager::CreateSampler(std::shared_ptr<SamplerRequest> request)
 	samplerCreateInfo.minLod = 0.0f;
 	samplerCreateInfo.maxLod = request->MaxLod;
 
+	if (request->MipmapMode == D3DTEXF_NONE)
+	{
+		samplerCreateInfo.maxLod = 0.0f;
+	}
+
 	mResult = vkCreateSampler(mDevice->mDevice, &samplerCreateInfo, NULL, &request->Sampler);
 	if (mResult != VK_SUCCESS)
 	{

--- a/VK9-Library/BufferManager.cpp
+++ b/VK9-Library/BufferManager.cpp
@@ -1677,7 +1677,16 @@ void BufferManager::CreateSampler(std::shared_ptr<SamplerRequest> request)
 	{
 		// Use max. level of anisotropy for this example
 		samplerCreateInfo.maxAnisotropy = min(request->MaxAnisotropy, mDevice->mDeviceProperties.limits.maxSamplerAnisotropy);
-		samplerCreateInfo.anisotropyEnable = VK_TRUE;
+		
+		if (request->MinFilter == D3DTEXF_ANISOTROPIC ||
+			request->MagFilter == D3DTEXF_ANISOTROPIC ||
+			request->MipmapMode == D3DTEXF_ANISOTROPIC)
+		{
+			samplerCreateInfo.anisotropyEnable = VK_TRUE;
+		}
+		else {
+			samplerCreateInfo.anisotropyEnable = VK_FALSE;
+		}
 	}
 	else
 	{

--- a/VK9-Library/BufferManager.cpp
+++ b/VK9-Library/BufferManager.cpp
@@ -672,7 +672,7 @@ void BufferManager::BeginDraw(std::shared_ptr<DrawContext> context, std::shared_
 			request->AddressModeW = (D3DTEXTUREADDRESS)mDevice->mDeviceState.mSamplerStates[request->SamplerIndex][D3DSAMP_ADDRESSW];
 			request->MaxAnisotropy = mDevice->mDeviceState.mSamplerStates[request->SamplerIndex][D3DSAMP_MAXANISOTROPY];
 			request->MipmapMode = (D3DTEXTUREFILTERTYPE)mDevice->mDeviceState.mSamplerStates[request->SamplerIndex][D3DSAMP_MIPFILTER];
-			request->MipLodBias = (float)mDevice->mDeviceState.mSamplerStates[request->SamplerIndex][D3DSAMP_MIPMAPLODBIAS];
+			request->MipLodBias = *(float*)&mDevice->mDeviceState.mSamplerStates[request->SamplerIndex][D3DSAMP_MIPMAPLODBIAS];
 			request->MaxLod = pair1.second->mLevels;
 
 			for (size_t i = 0; i < mSamplerRequests.size(); i++)


### PR DESCRIPTION
the texture mipmapping sample did not work completely.

- Disabling texture mapping wasn't honored
- mipmapping lod bias value was wrongly converted into a float

This pull request should fix those issues. Also I enabled anistropic filtering only when it's really requested from the application.