### PR TITLE
Cleaned up RenderDoc.dll/d3d9.dll loading, charset incosistencies

### DIFF
--- a/VK9-Library/Perf_CommandStreamManager.cpp
+++ b/VK9-Library/Perf_CommandStreamManager.cpp
@@ -58,8 +58,8 @@ CommandStreamManager::CommandStreamManager()
 		if (!outfile)
 		{
 			MessageBox(nullptr,
-				L"The application does not have permission to write to the log file location. If running on Windows try running as administrator.",
-				L"No Write Permission!",
+				TEXT("The application does not have permission to write to the log file location. If running on Windows try running as administrator."),
+				TEXT("No Write Permission!"),
 				IDOK | MB_ICONERROR);
 		}
 		outfile.close();
@@ -76,8 +76,8 @@ CommandStreamManager::CommandStreamManager()
 		if (!outfile)
 		{
 			MessageBox(nullptr,
-				L"The application does not have permission to write to the log file location. If running on Windows try running as administrator.",
-				L"No Write Permission!",
+				TEXT("The application does not have permission to write to the log file location. If running on Windows try running as administrator."),
+				TEXT("No Write Permission!"),
 				IDOK | MB_ICONERROR);
 		}
 		outfile.close();

--- a/VK9-Library/Perf_StateManager.cpp
+++ b/VK9-Library/Perf_StateManager.cpp
@@ -815,11 +815,10 @@ void StateManager::CreateInstance()
 	extensionNames.push_back("VK_EXT_debug_report");
 	layerNames.push_back("VK_LAYER_LUNARG_standard_validation");
 
-	HINSTANCE instance = LoadLibraryA("renderdoc.dll");
-	HMODULE mod = GetModuleHandleA("renderdoc.dll");
-	if (mod != nullptr)
+	BOOL res = GetModuleHandleEx(0, TEXT("renderdoc"), &ptr->mRenderDocDll);
+	if (res != FALSE)
 	{
-		pRENDERDOC_GetAPI RENDERDOC_GetAPI = (pRENDERDOC_GetAPI)GetProcAddress(mod, "RENDERDOC_GetAPI");
+		pRENDERDOC_GetAPI RENDERDOC_GetAPI = (pRENDERDOC_GetAPI)GetProcAddress(ptr->mRenderDocDll, "RENDERDOC_GetAPI");
 		if (RENDERDOC_GetAPI != nullptr)
 		{
 			int ret = RENDERDOC_GetAPI(eRENDERDOC_API_Version_1_1_1, (void **)&ptr->mRenderDocApi);

--- a/VK9-Library/RealInstance.cpp
+++ b/VK9-Library/RealInstance.cpp
@@ -31,6 +31,10 @@ RealInstance::~RealInstance()
 	mDevices.clear();
 #ifdef _DEBUG
 	mInstance.destroyDebugReportCallbackEXT(mCallback);
+	if ( mRenderDocDll != nullptr )
+	{
+		FreeLibrary(mRenderDocDll);
+	}
 #endif
 	mInstance.destroy();
 }

--- a/VK9-Library/RealInstance.h
+++ b/VK9-Library/RealInstance.h
@@ -43,6 +43,7 @@ struct RealInstance
 	boost::container::small_vector<std::shared_ptr<RealDevice>, 1> mDevices;
 
 #ifdef _DEBUG
+	HMODULE mRenderDocDll = nullptr;
 	RENDERDOC_API_1_1_1* mRenderDocApi = nullptr;
 	vk::DebugReportCallbackEXT mCallback;
 #endif // _DEBUG

--- a/VK9-Library/Utilities.cpp
+++ b/VK9-Library/Utilities.cpp
@@ -828,7 +828,7 @@ vk::ShaderModule LoadShaderFromResource(vk::Device device, WORD resource)
 	}
 	else
 	{
-		HRSRC hRes = FindResource(dllModule, MAKEINTRESOURCE(resource), L"Shader");
+		HRSRC hRes = FindResource(dllModule, MAKEINTRESOURCE(resource), TEXT("Shader"));
 		if (NULL != hRes)
 		{
 			HGLOBAL hData = LoadResource(dllModule, hRes);

--- a/VK9-Library/Utilities.cpp
+++ b/VK9-Library/Utilities.cpp
@@ -820,9 +820,9 @@ vk::ShaderModule LoadShaderFromResource(vk::Device device, WORD resource)
 	HMODULE dllModule = NULL;
 
 	//dllModule = GetModule();
-	dllModule = GetModuleHandle(L"D3d9.dll");
+	BOOL res = GetModuleHandleEx(0, TEXT("d3d9"), &dllModule);
 
-	if (dllModule == NULL)
+	if (res == FALSE)
 	{
 		BOOST_LOG_TRIVIAL(fatal) << "LoadShaderFromResource dllModule is null.";
 	}
@@ -859,6 +859,8 @@ vk::ShaderModule LoadShaderFromResource(vk::Device device, WORD resource)
 		{
 			BOOST_LOG_TRIVIAL(fatal) << "LoadShaderFromResource resource not found.";
 		}
+
+		FreeLibrary(dllModule);
 	}
 
 	return module;


### PR DESCRIPTION
This PR consists of three commits, two of which introduce minor corrections to the way DLL handles are obtained, and the third one being a tiny correction to ensure multibyte/Unicode handling is fully consistent throughought the codebase.

1. renderdoc.dll was loaded using `LoadLibrary` and then `GetModuleHandle`. Former cannot work with RenderDoc DLL since it's not in any of known paths by default (**however**, if this by any change ever succeeded, then the handle leaked), and thus I think the intended behaviour was to obtain handle from a loaded module. However, this could be subject to a (very unlikely) race condition where renderdoc.dll unloads **before** all VK9 code relying on it finishes. Using `GetModuleHandleEx` and freeing the handle from `RealInstance` destructor ensures this will never be the case.
2. d3d9.dll could potentially face a similar problem -- albeit unlikely, it was not guaranteed it stays loaded before the code using it is finished. Now it is guaranteed.