### PR TITLE
Add winetricks installation verb

### DIFF
--- a/VK9-Library/Perf_CommandStreamManager.cpp
+++ b/VK9-Library/Perf_CommandStreamManager.cpp
@@ -50,14 +50,22 @@ CommandStreamManager::CommandStreamManager()
 		("LogLevel", boost::program_options::value<uint32_t>(), "The level of the log file.")
 		("EnableDebugLayers", boost::program_options::value<uint32_t>(), "Enable validation layers?");
 
-	boost::program_options::store(boost::program_options::parse_config_file<char>("VK9.conf", mOptionDescriptions), mOptions);
-	boost::program_options::notify(mOptions);
-
 	boost::log::add_console_log(
 		std::cout, 
 		boost::log::keywords::format = "[%TimeStamp%]: %Message%",
 		boost::log::keywords::auto_flush = true
 	);
+
+	try
+	{
+		boost::program_options::store(boost::program_options::parse_config_file<char>("VK9.conf", mOptionDescriptions), mOptions);
+	}
+	catch(const std::exception& ex)
+	{
+		BOOST_LOG_TRIVIAL(warning) << "program_options::parse_config_file: " << ex.what()
+								   << ", using default values";
+	}
+	boost::program_options::notify(mOptions);
 
 	if (mOptions.count("LogFile"))
 	{

--- a/package-release.sh
+++ b/package-release.sh
@@ -119,6 +119,7 @@ function build_arch {
   cp "$VK9_BUILD_DIR/install.$1/bin/d3d9.dll" "$VK9_BUILD_DIR/x$1/d3d9.dll"
   cp "$VK9_SRC_DIR/VK9-Library/VK9.conf" "$VK9_BUILD_DIR/x$1/VK9.conf"
   cp "$VK9_BUILD_DIR/install.$1/bin/setup_vk9.sh" "$VK9_BUILD_DIR/x$1/setup_vk9.sh"
+  cp "$VK9_SRC_DIR/wine_utils/setup_vk9.verb" "$VK9_BUILD_DIR/setup_vk9.verb"
 
   if [ $KEEP_BUILDDIR == false ]; then
     rm -R "$VK9_BUILD_DIR/build.$1"
@@ -150,9 +151,7 @@ function package {
   if [ -d "vk9-$VK9_VERSION/x32" ]; then
     TAR_DIRS="$TAR_DIRS vk9-$VK9_VERSION/x32"
   fi
-  if [ -d "vk9-$VK9_VERSION/Shaders" ]; then
-    TAR_DIRS="$TAR_DIRS vk9-$VK9_VERSION/Shaders"
-  fi
+  TAR_DIRS="$TAR_DIRS vk9-$VK9_VERSION/setup_vk9.verb"
 
   tar -czvf "$VK9_ARCHIVE_PATH" $TAR_DIRS
   if [ $KEEP_BUILDDIR == false ]; then

--- a/wine_utils/setup_vk9.verb
+++ b/wine_utils/setup_vk9.verb
@@ -1,0 +1,28 @@
+w_metadata setup_vk9 dlls \
+    title="VK9" \
+    publisher="Christopher Joseph Dean Schaefer" \
+    year="2018" \
+    media="manual_download" \
+    file="d3d9.dll" \
+    installed_file="$W_SYSTEM32_DLLS_WIN/d3d9.dll" \
+    homepage="https://github.com/disks86/VK9"
+
+VK9_ROOT_DIR=`dirname "$(readlink -f $1)"`
+
+load_setup_vk9()
+{
+    if [ ! -e "$VK9_ROOT_DIR/x64" ] || [ ! -e "$VK9_ROOT_DIR/x32" ]; then
+        (>&2 echo "$VK9_ROOT_DIR/x32 or $VK9_ROOT_DIR/x64 directory not found.")
+        exit 1
+    fi
+
+    w_try cp "$VK9_ROOT_DIR/x32/$file" "$W_SYSTEM32_DLLS/$file"
+
+    if [ "$W_ARCH" = "win64" ]; then
+        vk9_64_dir="/usr/lib64/wine/vk9"
+        w_try cp "$VK9_ROOT_DIR/x64/$file" "$W_SYSTEM64_DLLS/$file"
+    fi
+
+    w_override_dlls native \
+        d3d9
+}


### PR DESCRIPTION
This adds a winetricks installation verb (based on DXVK) and allows to run VK9 with default settings if "VK9.conf" does not exist in the current working directory.